### PR TITLE
test: use pytest.approx compare float number

### DIFF
--- a/tests/test_tairhash.py
+++ b/tests/test_tairhash.py
@@ -4,6 +4,8 @@ import datetime
 import time
 import uuid
 
+from pytest import approx
+
 from tair import (
     ExhscanResult,
     FieldValueItem,
@@ -533,8 +535,8 @@ class TestTairHash:
         field = "field_" + str(uuid.uuid4())
 
         assert t.exhset(key, field, 1.1) == 1
-        assert t.exhincrbyfloat(key, field, 2.2) == 3.3
-        assert t.exhget(key, field) == b"3.3"
+        assert t.exhincrbyfloat(key, field, 2.2) == approx(3.3)
+        assert float(t.exhget(key, field)) == approx(3.3)
 
     def test_exhincrbyfloat_ex(self):
         t = get_tair_client()
@@ -542,7 +544,7 @@ class TestTairHash:
         field = "field_" + str(uuid.uuid4())
 
         assert t.exhset(key, field, 1.1) == 1
-        assert t.exhincrbyfloat(key, field, 2.2, ex=10) == 3.3
+        assert t.exhincrbyfloat(key, field, 2.2, ex=10) == approx(3.3)
         assert 0 < t.exhttl(key, field) <= 10
 
         # ex should not be a float.
@@ -556,7 +558,7 @@ class TestTairHash:
         ex = datetime.timedelta(seconds=10)
 
         assert t.exhset(key, field, 1.1) == 1
-        assert t.exhincrbyfloat(key, field, 2.2, ex=ex) == 3.3
+        assert t.exhincrbyfloat(key, field, 2.2, ex=ex) == approx(3.3)
         assert 0 < t.exhttl(key, field) <= 10
 
     def test_exhincrbyfloat_px(self):
@@ -565,7 +567,7 @@ class TestTairHash:
         field = "field_" + str(uuid.uuid4())
 
         assert t.exhset(key, field, 1.1) == 1
-        assert t.exhincrbyfloat(key, field, 2.2, px=10000) == 3.3
+        assert t.exhincrbyfloat(key, field, 2.2, px=10000) == approx(3.3)
         assert 0 < t.exhpttl(key, field) <= 10000
 
         # px should not be a float.
@@ -579,7 +581,7 @@ class TestTairHash:
         px = datetime.timedelta(milliseconds=10000)
 
         assert t.exhset(key, field, 1.1) == 1
-        assert t.exhincrbyfloat(key, field, 2.2, px=px) == 3.3
+        assert t.exhincrbyfloat(key, field, 2.2, px=px) == approx(3.3)
         assert 0 < t.exhpttl(key, field) <= 10000
 
     def test_exhincrbyfloat_exat(self):
@@ -590,7 +592,7 @@ class TestTairHash:
         exat = int(time.mktime(expire_at.timetuple()))
 
         assert t.exhset(key, field, 1.1) == 1
-        assert t.exhincrbyfloat(key, field, 2.2, exat=exat) == 3.3
+        assert t.exhincrbyfloat(key, field, 2.2, exat=exat) == approx(3.3)
         assert 0 < t.exhttl(key, field) <= 10
 
     def test_exhincrbyfloat_exat_timedelta(self):
@@ -600,7 +602,7 @@ class TestTairHash:
         expire_at = get_server_time(t) + datetime.timedelta(seconds=10)
 
         assert t.exhset(key, field, 1.1) == 1
-        assert t.exhincrbyfloat(key, field, 2.2, exat=expire_at) == 3.3
+        assert t.exhincrbyfloat(key, field, 2.2, exat=expire_at) == approx(3.3)
         assert 0 < t.exhttl(key, field) <= 10
 
     def test_exhincrbyfloat_pxat(self):
@@ -611,7 +613,7 @@ class TestTairHash:
         pxat = int(time.mktime(expire_at.timetuple())) * 1000
 
         assert t.exhset(key, field, 1.1) == 1
-        assert t.exhincrbyfloat(key, field, 2.2, pxat=pxat) == 3.3
+        assert t.exhincrbyfloat(key, field, 2.2, pxat=pxat) == approx(3.3)
         assert 0 < t.exhpttl(key, field) <= 10000
 
     def test_exhincrbyfloat_pxat_timedelta(self):
@@ -621,7 +623,7 @@ class TestTairHash:
         pxat = get_server_time(t) + datetime.timedelta(seconds=10)
 
         assert t.exhset(key, field, 1.1) == 1
-        assert t.exhincrbyfloat(key, field, 2.2, pxat=pxat) == 3.3
+        assert t.exhincrbyfloat(key, field, 2.2, pxat=pxat) == approx(3.3)
         # due to network delay, pttl may be greater than 10000.
         assert 0 < t.exhpttl(key, field) <= (10000 + NETWORK_DELAY_CALIBRATION_VALUE)
 
@@ -632,8 +634,8 @@ class TestTairHash:
         field2 = "field_" + str(uuid.uuid4())
 
         assert t.exhset(key, field1, 1.1) == 1
-        assert t.exhincrbyfloat(key, field1, 2.2, ver=1) == 3.3
-        assert t.exhget(key, field1) == b"3.3"
+        assert t.exhincrbyfloat(key, field1, 2.2, ver=1) == approx(3.3)
+        assert float(t.exhget(key, field1)) == approx(3.3)
         assert t.exhver(key, field1) == 2
 
         assert t.exhset(key, field2, 10) == 1
@@ -646,8 +648,8 @@ class TestTairHash:
         field = "field_" + str(uuid.uuid4())
 
         assert t.exhset(key, field, 1.1) == 1
-        assert t.exhincrbyfloat(key, field, 2.2, abs=100) == 3.3
-        assert t.exhget(key, field) == b"3.3"
+        assert t.exhincrbyfloat(key, field, 2.2, abs=100) == approx(3.3)
+        assert float(t.exhget(key, field)) == approx(3.3)
         assert t.exhver(key, field) == 100
 
     def test_exhincrbyfloat_overflow(self):
@@ -669,7 +671,7 @@ class TestTairHash:
         pxat = int(time.mktime(exat.timetuple())) * 1000
 
         assert t.exhset(key, field, 1.1, pxat=pxat) == 1
-        assert t.exhincrbyfloat(key, field, 2.2, keepttl=True) == 3.3
+        assert t.exhincrbyfloat(key, field, 2.2, keepttl=True) == approx(3.3)
         assert 0 < t.exhpttl(key, field) <= 10000
 
     def test_exhgetwithver(self):

--- a/tests/test_tairstring.py
+++ b/tests/test_tairstring.py
@@ -4,6 +4,8 @@ import datetime
 import time
 import uuid
 
+from pytest import approx
+
 from .conftest import get_tair_client, get_server_time, NETWORK_DELAY_CALIBRATION_VALUE
 
 from tair import ExgetResult, ExcasResult, DataError, ResponseError
@@ -320,9 +322,9 @@ class TestTairString:
         key = "key_" + str(uuid.uuid4())
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2) == 3.3
+        assert t.exincrbyfloat(key, 2.2) == approx(3.3)
         result = t.exget(key)
-        assert result.value == b"3.3"
+        assert float(result.value) == pytest.approx(3.3)
         assert result.version == 2
 
     def test_exincrbyfloat_ex(self):
@@ -330,7 +332,7 @@ class TestTairString:
         key = "key_" + str(uuid.uuid4())
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2, ex=10) == 3.3
+        assert t.exincrbyfloat(key, 2.2, ex=10) == approx(3.3)
         assert 0 < t.ttl(key) <= 10
 
         # ex should not be a float.
@@ -343,7 +345,7 @@ class TestTairString:
         expire_at = datetime.timedelta(seconds=10)
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2, ex=expire_at) == 3.3
+        assert t.exincrbyfloat(key, 2.2, ex=expire_at) == approx(3.3)
         assert 0 < t.ttl(key) <= 10
 
     def test_exincrbyfloat_px(self):
@@ -351,7 +353,7 @@ class TestTairString:
         key = "key_" + str(uuid.uuid4())
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2, px=10000) == 3.3
+        assert t.exincrbyfloat(key, 2.2, px=10000) == approx(3.3)
         assert 0 < t.pttl(key) <= 10000
 
         # px should not be a float.
@@ -364,7 +366,7 @@ class TestTairString:
         expire_at = datetime.timedelta(milliseconds=10000)
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2, px=expire_at) == 3.3
+        assert t.exincrbyfloat(key, 2.2, px=expire_at) == approx(3.3)
         assert 0 < t.pttl(key) <= 10000
 
     def test_exincrbyfloat_exat(self):
@@ -374,7 +376,7 @@ class TestTairString:
         exat = int(time.mktime(expire_at.timetuple()))
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2, exat=exat) == 3.3
+        assert t.exincrbyfloat(key, 2.2, exat=exat) == approx(3.3)
         assert 0 < t.ttl(key) <= 10
 
     def test_exincrbyfloat_exat_timedelta(self):
@@ -383,7 +385,7 @@ class TestTairString:
         expire_at = get_server_time(t) + datetime.timedelta(seconds=10)
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2, exat=expire_at) == 3.3
+        assert t.exincrbyfloat(key, 2.2, exat=expire_at) == approx(3.3)
         assert 0 < t.ttl(key) <= 10
 
     def test_exincrbyfloat_pxat(self):
@@ -393,7 +395,7 @@ class TestTairString:
         pxat = int(time.mktime(expire_at.timetuple())) * 1000
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2, pxat=pxat) == 3.3
+        assert t.exincrbyfloat(key, 2.2, pxat=pxat) == approx(3.3)
         # due to network delay, pttl may be greater than 10000.
         assert 0 < t.pttl(key) <= (10000 + NETWORK_DELAY_CALIBRATION_VALUE)
 
@@ -403,7 +405,7 @@ class TestTairString:
         expire_at = get_server_time(t) + datetime.timedelta(seconds=10)
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2, pxat=expire_at) == 3.3
+        assert t.exincrbyfloat(key, 2.2, pxat=expire_at) == approx(3.3)
         # due to network delay, pttl may be greater than 10000.
         assert 0 < t.pttl(key) <= (10000 + NETWORK_DELAY_CALIBRATION_VALUE)
 
@@ -414,13 +416,13 @@ class TestTairString:
 
         assert t.exincrbyfloat(key1, 1.1, nx=True) == 1.1
         result = t.exget(key1)
-        assert result.value == b"1.1"
+        assert float(result.value) == approx(1.1)
         assert result.version == 1
 
         assert t.exset(key2, 1.1)
         assert t.exincrbyfloat(key2, 2.2, nx=True) is None
         result = t.exget(key2)
-        assert result.value == b"1.1"
+        assert float(result.value) == approx(1.1)
         assert result.version == 1
 
     def test_exincrbyfloat_xx(self):
@@ -432,9 +434,9 @@ class TestTairString:
         assert not t.exists(key1)
 
         assert t.exset(key2, 1.1)
-        assert t.exincrbyfloat(key2, 2.2, xx=True) == 3.3
+        assert t.exincrbyfloat(key2, 2.2, xx=True) == approx(3.3)
         result = t.exget(key2)
-        assert result.value == b"3.3"
+        assert float(result.value) == approx(3.3)
         assert result.version == 2
 
     def test_exincrbyfloat_ver(self):
@@ -442,9 +444,9 @@ class TestTairString:
         key = "key_" + str(uuid.uuid4())
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2, ver=1) == 3.3
+        assert t.exincrbyfloat(key, 2.2, ver=1) == approx(3.3)
         result = t.exget(key)
-        assert result.value == b"3.3"
+        assert float(result.value) == approx(3.3)
         assert result.version == 2
 
         assert t.exset(key, 1.1)
@@ -456,9 +458,9 @@ class TestTairString:
         key = "key_" + str(uuid.uuid4())
 
         assert t.exset(key, 1.1)
-        assert t.exincrbyfloat(key, 2.2, abs=100) == 3.3
+        assert t.exincrbyfloat(key, 2.2, abs=100) == approx(3.3)
         result = t.exget(key)
-        assert result.value == b"3.3"
+        assert float(result.value) == approx(3.3)
         assert result.version == 100
 
     def test_exincrbyfloat_overflow(self):


### PR DESCRIPTION
error stack in macOS Apple M1 Pro
```
self = <tests.test_tairhash.TestTairHash object at 0x106aee3d0>

    def test_exhincrbyfloat_px_timedelta(self):
        t = get_tair_client()
        key = "key_" + str(uuid.uuid4())
        field = "field_" + str(uuid.uuid4())
        px = datetime.timedelta(milliseconds=10000)

        assert t.exhset(key, field, 1.1) == 1
>       assert t.exhincrbyfloat(key, field, 2.2, px=px) == 3.3
E       AssertionError: assert 3.3000000000000003 == 3.3
E        +  where 3.3000000000000003 = <bound method TairHashCommands.exhincrbyfloat of Tair<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>>('key_8db371ab-3267-403f-9ecc-b949120c0515', 'field_d660c80f-467b-4f5a-8f7f-d17332e8e0ae', 2.2, px=datetime.timedelta(seconds=10))
E        +    where <bound method TairHashCommands.exhincrbyfloat of Tair<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>> = Tair<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>.exhincrbyfloat
```